### PR TITLE
Fix CFBundlePackageType (AAPL to APPL)

### DIFF
--- a/docs/distribution-publishing/macos.md
+++ b/docs/distribution-publishing/macos.md
@@ -107,7 +107,7 @@ Instead of specifying `CFBundleDisplayName`, etc., on the command line, you can 
     <CFBundleDisplayName>MyBestThingEver</CFBundleDisplayName>
     <CFBundleIdentifier>com.example</CFBundleIdentifier>
     <CFBundleVersion>1.0.0</CFBundleVersion>
-    <CFBundlePackageType>AAPL</CFBundlePackageType>
+    <CFBundlePackageType>APPL</CFBundlePackageType>
     <CFBundleSignature>????</CFBundleSignature>
     <CFBundleExecutable>AppName</CFBundleExecutable>
     <CFBundleIconFile>AppName.icns</CFBundleIconFile> <!-- Will be copied from output directory -->


### PR DESCRIPTION
Should be `APPL`, not `AAPL`. I think this was fixed on the old docs site: https://github.com/AvaloniaUI/avaloniaui.net/pull/245