### PR TITLE
Update Apple Documentation Link

### DIFF
--- a/docs/distribution-publishing/macos.md
+++ b/docs/distribution-publishing/macos.md
@@ -28,7 +28,7 @@ MyProgram.app
     ------Info.plist [stores information on your bundle identifier, version, etc.)
 ```
 
-For more information on `Info.plist`, see [Apple's documentation here](https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Introduction/Introduction.html).
+For more information on `Info.plist`, see [Apple's documentation here](https://developer.apple.com/documentation/bundleresources/information_property_list).
 
 ### Making the application bundle <a id="making-the-application-bundle"></a>
 


### PR DESCRIPTION
[Original from AvaloniaUI/avaloniaui.net/pull/244](https://github.com/AvaloniaUI/avaloniaui.net/pull/244)

---

**What kind of change does this PR introduce?**

Update the link of `Information Property List` from the old `developer.apple.com/library` to the new `developer.apple.com/documentation`.

**What is the current behavior?**

The old `developer.apple.com/library` link



**What is the new behavior?**

Link to Info.plist section of the new `developer.apple.com/documentation`
