### PR TITLE
Fixed broken links in ReactiveUI guide

### DIFF
--- a/guides/deep-dives/reactiveui/README.md
+++ b/guides/deep-dives/reactiveui/README.md
@@ -30,7 +30,7 @@ To get started with ReactiveUI, see the [Getting Started](https://reactiveui.net
 
 ### In This Section <a id="in-this-section"></a>
 
-* [View Activation](http://avaloniaui.net/docs/reactiveui/activation)
-* [Routing](http://avaloniaui.net/docs/reactiveui/routing)
-* [Data Persistence](http://avaloniaui.net/docs/reactiveui/suspension)
+* [View Activation](https://docs.avaloniaui.net/guides/deep-dives/reactiveui/view-activation)
+* [Routing](https://docs.avaloniaui.net/guides/deep-dives/reactiveui/routing)
+* [Data Persistence](https://docs.avaloniaui.net/guides/deep-dives/reactiveui/data-persistence)
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1926484/123330563-dac98900-d546-11eb-8a5f-44811f4b90ac.png)
These links produce HTTP 404. I fixed them with the actual URLs.