### PR TITLE
Fixed incorrect links in `intoduction-to-xaml.md` and `mvvm.md`

### DIFF
--- a/guides/basics/introduction-to-xaml.md
+++ b/guides/basics/introduction-to-xaml.md
@@ -25,7 +25,7 @@ A basic Avalonia XAML file looks like this:
 
 There are three parts to this file:
 
-* The root element `Window` - this descibes the type of the root control in the XAML file; in this case [`Window`](http://avaloniaui.net/api/Avalonia.Controls/Window/)
+* The root element `Window` - this descibes the type of the root control in the XAML file; in this case [`Window`](http://reference.avaloniaui.net/api/Avalonia.Controls/Window/)
 * `xmlns="https://github.com/avaloniaui"` - this is the XAML namespace for Avalonia. Without this, the file will not be recognised as an Avalonia XAML document.
 * `xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"` - this is the XAML-language XAML namespace. This isn't strictly necessary, but you will probably need it for accessing certain features of the XAML language.
 * `x:Class="AvaloniaApplication1.MainWindow"` - this tells the XAML compiler where to find the associated class for this file, defined in [code-behind](https://docs.avaloniaui.net/guides/basics/code-behind)
@@ -67,7 +67,7 @@ You may notice that the button above has its "Hello World!" content placed direc
 </Window>
 ```
 
-This is because [`Button.Content`](http://avaloniaui.net/api/Avalonia.Controls/ContentControl/4B02A756) is declared as a _`[Content]` Property_ which means that any content placed inside its XML tag will be assigned to this property.
+This is because [`Button.Content`](http://reference.avaloniaui.net/api/Avalonia.Controls/ContentControl/) is declared as a _`[Content]` Property_ which means that any content placed inside its XML tag will be assigned to this property.
 
 ## Binding <a id="binding"></a>
 
@@ -80,9 +80,9 @@ You can bind a property using the `{Binding}` markup extension:
 </Window>
 ```
 
-For more information, see the [binding documentation](http://avaloniaui.net/docs/binding).
+For more information, see the [binding documentation](https://docs.avaloniaui.net/docs/data-binding).
 
 ## Code-behind <a id="code-behind"></a>
 
-Many XAML files also have an associated _code-behind_ file which usually has the extension `.xaml.cs`. For more information see the [codebehind documentation](http://avaloniaui.net/docs/quickstart/codebehind).
+Many XAML files also have an associated _code-behind_ file which usually has the extension `.xaml.cs`. For more information see the [codebehind documentation](https://docs.avaloniaui.net/guides/basics/code-behind).
 

--- a/guides/basics/mvvm.md
+++ b/guides/basics/mvvm.md
@@ -4,9 +4,9 @@ description: Understanding the Model-View-ViewModel architectural pattern.
 
 # MVVM Architecture
 
-The Model-View-ViewModel pattern \(MVVM\) is a common way of structuring a UI application. It takes advantage of Avalonia's [binding](http://avaloniaui.net/docs/binding/bindings) system to separate the logic of the application from the display of the application.
+The Model-View-ViewModel pattern \(MVVM\) is a common way of structuring a UI application. It takes advantage of Avalonia's [binding](https://docs.avaloniaui.net/docs/data-binding) system to separate the logic of the application from the display of the application.
 
-MVVM might be overkill for a simple application, but as applications grow over time, they usually reach a point where tracking logic in [code-behind](http://avaloniaui.net/docs/quickstart/codebehind) becomes problematic for two main reasons:
+MVVM might be overkill for a simple application, but as applications grow over time, they usually reach a point where tracking logic in [code-behind](https://docs.avaloniaui.net/guides/basics/code-behind) becomes problematic for two main reasons:
 
 * The interactions between UI components becomes overly complicated and error-prone
 * It's very difficult to unit test code in code-behind
@@ -25,7 +25,7 @@ Many people prefer to start off their application using code-behind and once thi
 
 ### Views and ViewModels <a id="views-and-viewmodels"></a>
 
-When we talk about the MVVM pattern, the most important parts are the **View** layer and the **ViewModel** layer. Views are usually implemented as [`Window`](http://avaloniaui.net/docs/quickstart/window)s and [`UserControl`](http://avaloniaui.net/docs/quickstart/usercontrol)s while ViewModels are .NET classes.
+When we talk about the MVVM pattern, the most important parts are the **View** layer and the **ViewModel** layer. Views are usually implemented as [`Window`](https://docs.avaloniaui.net/docs/controls/window)s and [`UserControl`](https://docs.avaloniaui.net/docs/controls/usercontrol)s while ViewModels are .NET classes.
 
 One way to imagine an MVVM application is to imagine these two layers as hovering over one another, connected by bindings:
 


### PR DESCRIPTION
Several links in `introduction-to-xaml.md` (guides/basics/introduction-to-xaml.md) leading to a 404 response have been updated to their (probably) correct location. I tried to find the most probable link that's fitting the content of the old link, based on it's name.

- Reference to 'Window' documentation
Earlier: http://avaloniaui.net/api/Avalonia.Controls/Window/
Now: http://reference.avaloniaui.net/api/Avalonia.Controls/Window/

- Reference to 'ContentControl' (referred as 'Button.Content' in the text)
Earlier: http://avaloniaui.net/api/Avalonia.Controls/ContentControl/4B02A756, 
Now: http://reference.avaloniaui.net/api/Avalonia.Controls/ContentControl/

- Reference to 'Binding' documentation
Earlier: http://avaloniaui.net/docs/binding
Now (most probable match): https://docs.avaloniaui.net/docs/data-binding

- Reference to 'code-behind' documentation
Earlier: http://avaloniaui.net/docs/quickstart/code-behind
Now: https://docs.avaloniaui.net/guides/basics/code-behind