### PR TITLE
Add section on how to bind to objects implementing INotifyPropertyChanged

### DIFF
--- a/docs/data-binding/binding-from-code.md
+++ b/docs/data-binding/binding-from-code.md
@@ -152,3 +152,18 @@ private void FooChanged(AvaloniaPropertyChangedEventArgs e)
 }
 ```
 
+## Binding to Objects that Implement INotifyPropertyChanged
+
+Binding to objects that implement `INotifyPropertyChanged` is also available.
+
+```csharp 
+var textBlock = new TextBlock();
+
+var binding = new Binding 
+{ 
+    Source = someObjectImplementingINotifyPropertyChanged, 
+    Path = nameof(someObjectImplementingINotifyPropertyChanged.MyProperty)
+}; 
+
+textBlock.Bind(TextBlock.TextProperty, binding);
+```


### PR DESCRIPTION
This adds a brief section on how to bind objects that implement `INotifyPropertyChanged` from code.