### PR TITLE
minor formattings

### DIFF
--- a/docs/getting-started/programming-with-avalonia/README.md
+++ b/docs/getting-started/programming-with-avalonia/README.md
@@ -23,15 +23,19 @@ The following example uses XAML to implement the appearance of a window that con
 
 Specifically, this XAML defines a window and a button by using the Window and Button elements, respectively. Each element is configured with attributes, such as the Window element's Title attribute to specify the window's title-bar text. At run time, Avalonia converts the elements and attributes that are defined in markup to instances of Avalonia classes. For example, the Window element is converted to an instance of the Window class whose Title property is the value of the Title attribute.
 
-The following images show the user interface that is defined by the XAML in the previous example running on Windows:
-
 Since XAML is XML-based, the UI that you compose with it is assembled in a hierarchy of nested elements known as an element tree. The element tree provides a logical and intuitive way to create and manage UIs.
+
+The following images show the user interface that is defined by the XAML in the previous example running on Windows:
 
 ![](../../../.gitbook/assets/click-me.png)
 
 ## Code-behind
 
-The main behavior of an application is to implement the functionality that responds to user interactions, including handling events \(for example, clicking a menu, tool bar, or button\) and calling business logic and data access logic in response. In Avalonia, this behavior can be implemented in code that is associated with markup. This type of code is known as [code-behind](https://docs.avaloniaui.net/guides/basics/code-behind). The following example shows the updated markup from the previous example and the code-behind:
+The main behavior of an application is to implement the functionality that responds to user interactions, including handling events \(for example, clicking a menu, tool bar, or button\) and calling business logic and data access logic in response. 
+
+In Avalonia, this behavior can be implemented in code that is associated with markup. This type of code is known as [code-behind](https://docs.avaloniaui.net/guides/basics/code-behind). 
+
+The following example shows the updated markup from the previous example and the code-behind \(note that there are 2 tabs\):
 
 {% tabs %}
 {% tab title="XAML" %}
@@ -82,5 +86,7 @@ namespace AvaloniaApplication1
 {% endtab %}
 {% endtabs %}
 
-In this example, the code-behind implements a class that derives from the [`Window`](https://docs.avaloniaui.net/docs/getting-started/windows) class. The `x:Class` attribute is used to associate the markup with the code-behind class. `InitializeComponent` is called from the code-behind class's constructor to merge the UI that is defined in markup with the code-behind class. The combination of `x:Class` and `InitializeComponent` ensure that your implementation is correctly initialised whenever it is created. The code-behind class also implements an event handler for the button's `Click` event. When the button is clicked, the event handler changes the text of the button by setting a property on the `Button` control.
+In this example, the code-behind implements a class that derives from the [`Window`](https://docs.avaloniaui.net/docs/getting-started/windows) class. The `x:Class` attribute is used to associate the markup with the code-behind class. `InitializeComponent` is called from the code-behind class's constructor to merge the UI that is defined in markup with the code-behind class. 
+
+The combination of `x:Class` and `InitializeComponent` ensure that your implementation is correctly initialised whenever it is created. The code-behind class also implements an event handler for the button's `Click` event. When the button is clicked, the event handler changes the text of the button by setting a property on the `Button` control.
 

--- a/docs/getting-started/programming-with-avalonia/controls-and-layouts.md
+++ b/docs/getting-started/programming-with-avalonia/controls-and-layouts.md
@@ -27,11 +27,11 @@ The cornerstone of the layout system is relative positioning, which increases th
 The layout system is exposed to child controls through base Avalonia classes. For common layouts such as grids, stacking, and docking, Avalonia includes several layout controls
 
 * [`Panel`](../../controls/panel.md): Child controls are stacked on top of each other to fill the panel
-* [`Canvas`](../../controls/canvas.md): Child controls provide their own layout
 * [`DockPanel`](../../controls/dockpanel.md): Child controls are aligned to the edges of the panel
-* [`Grid`](../../controls/grid.md): Child controls are positioned by rows and columns
 * [`StackPanel`](../../controls/stackpanel.md): Child controls are stacked either vertically or horizontally
 * [`WrapPanel`](../../controls/wrappanel.md): Child controls are positioned in left-to-right order and wrapped to the next line when there are more controls on the current line than space allows
+* [`Grid`](../../controls/grid.md): Child controls are positioned by rows and columns
+* [`Canvas`](../../controls/canvas.md): Child controls provide their own layout
 
 You can also create your own layouts by deriving from the [`Panel`](../../controls/panel.md) class.
 

--- a/docs/getting-started/programming-with-avalonia/the-model-view-viewmodel-pattern-mvvm.md
+++ b/docs/getting-started/programming-with-avalonia/the-model-view-viewmodel-pattern-mvvm.md
@@ -2,7 +2,9 @@
 
 As well as writing code in code-behind, Avalonia supports using the [Model-View-ViewModel](https://docs.avaloniaui.net/guides/basics/mvvm) pattern \(or MVVM\). MVVM is a common way to structure UI applications that separates view logic from application logic in a way that allows your applications to become unit-testable.
 
-MVVM relies upon Avalonia's [binding](https://docs.avaloniaui.net/docs/data-binding/bindings) capabilities to separate your application into a View layer which displays standard Avalonia windows and controls, and a ViewModel layer which defines the functionality of the application independently of Avalonia itself. The following example shows the code from the previous example implemented using the MVVM pattern:
+MVVM relies upon Avalonia's [binding](https://docs.avaloniaui.net/docs/data-binding/bindings) capabilities to separate your application into a View layer which displays standard Avalonia windows and controls, and a ViewModel layer which defines the functionality of the application independently of Avalonia itself. 
+
+The following example shows the code from the previous example implemented using the MVVM pattern:
 
 {% tabs %}
 {% tab title="XAML" %}

--- a/docs/templates/data-templates.md
+++ b/docs/templates/data-templates.md
@@ -27,7 +27,7 @@ Similarly if you put a string as the window content, the window will display the
 
 But what happens if you try to display an object as the window content?
 
-```text
+```csharp
 namespace Example
 {
     public class Student
@@ -44,7 +44,7 @@ namespace Example
 }
 ```
 
-```text
+```markup
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:local="clr-namespace:Example">
@@ -58,7 +58,7 @@ Not very helpful. That's because Avalonia doesn't know _how_ to display an objec
 
 The easiest way to do this on `Window` \(and any control that inherits from `ContentControl`\) is to set the [`ContentTemplate`](http://reference.avaloniaui.net/api/Avalonia.Controls/ContentControl/7AA9343E) property:
 
-```text
+```markup
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:local="clr-namespace:Example">


### PR DESCRIPTION
I do believe separating the paragraphs a bit more improves readability.

- changed code sections from `text` to `csharp` and `markup` in _docs/templates/data-templates.md_
- specified to look at both tabs (c# and XML) in _docs/getting-started/programming-with-avalonia/README.md_ as they could be potentially missed and cause confusion. Following the normal documentation order this would be the first time a reader encounters it.