### PR TITLE
Update macOS distribution -- remove unneeded name

### DIFF
--- a/docs/distribution-publishing/macos.md
+++ b/docs/distribution-publishing/macos.md
@@ -185,7 +185,7 @@ Create your `Info.plist` file, adding or modifying keys as necessary:
     <key>CFBundleIdentifier</key>
     <string>com.identifier</string>
     <key>CFBundleName</key>
-    <string>DotPurple</string>
+    <string>MyApp</string>
     <key>CFBundleVersion</key>
     <string>1.0.0</string>
     <key>LSMinimumSystemVersion</key>


### PR DESCRIPTION
Removes `DotPurple` as being the `CFBundleName` example and changes it to `MyApp` for more clarity. Sorry 'bout that.