### PR TITLE
Typo and wasm-tools clarification

### DIFF
--- a/tutorials/running-in-the-browser.md
+++ b/tutorials/running-in-the-browser.md
@@ -6,9 +6,9 @@ description: Run in the browser with WebAssembly
 
 It is currently very early days and not ready for production, however if you want to test this exciting new feature please take the following steps.
 
-1. Install ```wasm-tools``` wokrload tools. See [dotnet documentation](https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-workload-install).
+1. Install ```wasm-tools``` workload tools. See [dotnet documentation](https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-workload-install).
 
-2. install or update the dotnet templates to the latest version (0.10.11 or above).
+2. Install or update the dotnet templates to the latest version (0.10.11 or above).
 
 ```bash
 dotnet new -i avalonia.templates
@@ -34,3 +34,5 @@ cd WebTest.Web
 dotnet run
 ```
 
+## Troubleshooting
+If you have not performed the step to install `wasm-tools`, you will encounter errors when running the app in your browser later (e.g. `System.DllNotFoundException: libSkiaSharp`) and you will need to rebuild again before the app will run.


### PR DESCRIPTION
Minor update: 
- typo and consistency
- old docs didn't mention wasm-tools, so some users (like me) may have projects in an inconsistent state until they go back and do this step. I already develop Blazor apps but didn't appear to have these tools installed.