### PR TITLE
Minor fixes to JetBrains Rider setup page

### DIFF
--- a/docs/getting-started/ide-support/jetbrains-rider-setup.md
+++ b/docs/getting-started/ide-support/jetbrains-rider-setup.md
@@ -49,7 +49,7 @@ Click the `+` icon and enter the url `https://plugins.jetbrains.com/plugins/dev/
 
 ![enter-plugin-repo](https://avaloniaui.net/docs/advanced-tutorial/images/enter-plugin-repo.png)
 
-Now click on the `Marketplace` tab and search for `Avalonia`. Select `AvaloniaRider` and click `Install` then once thats done, click the `Restart IDE` button that will appear.
+Now click on the `Marketplace` tab and search for `Avalonia`. Select `AvaloniaRider` and click `Install`; once thats done, click the `Restart IDE` button that appears.
 
 ![plugin-install](https://avaloniaui.net/docs/advanced-tutorial/images/plugin-install.png)
 

--- a/docs/getting-started/ide-support/jetbrains-rider-setup.md
+++ b/docs/getting-started/ide-support/jetbrains-rider-setup.md
@@ -45,9 +45,13 @@ A new Preferenes Screen will open up. Click the `Settings` icon as shown and sel
 
 ![configure-plugin-repos](https://avaloniaui.net/docs/advanced-tutorial/images/configure-plugin-repos.png)
 
-Click the `+` icon and enter the url `https://plugins.jetbrains.com/plugins/dev/14839`then click `OK`![enter-plugin-repo](https://avaloniaui.net/docs/advanced-tutorial/images/enter-plugin-repo.png)
+Click the `+` icon and enter the url `https://plugins.jetbrains.com/plugins/dev/14839` then click `OK`:
 
-Now click on the `Marketplace` tab and search for `Avalonia`. Select `AvaloniaRider` and click `Install` then once thats done, click the `Restart IDE` button that will appear.![plugin-install](https://avaloniaui.net/docs/advanced-tutorial/images/plugin-install.png)
+![enter-plugin-repo](https://avaloniaui.net/docs/advanced-tutorial/images/enter-plugin-repo.png)
+
+Now click on the `Marketplace` tab and search for `Avalonia`. Select `AvaloniaRider` and click `Install` then once thats done, click the `Restart IDE` button that will appear.
+
+![plugin-install](https://avaloniaui.net/docs/advanced-tutorial/images/plugin-install.png)
 
 Now Rider should be ready to develop Avalonia applications.
 


### PR DESCRIPTION
This PR:

- Moves the "enter plugin repo" and "plugin install" images to a separate line (for me, it currently looks like [this](https://user-images.githubusercontent.com/31632386/156755814-30093b6e-01e5-4de3-bbbe-bd626a1a3c85.png), which is inconsistent with the rest of the page)
- Fixes spacing on the "enter plugin repo" line
- Fixes minor grammar issues on the "plugin install" line