### PR TITLE
README: fix stale .NET Standard link

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ and many other smaller companies.
 
 ## Supported .NET Version
 
-Avalonia is supported on [all platforms that support .NET Standard 2.0](https://github.com/dotnet/standard/blob/master/docs/versions/netstandard2.0.md#platform-support)
+Avalonia is supported on [all platforms that support .NET Standard 2.0](https://github.com/dotnet/standard/blob/release/3.0/docs/versions/netstandard2.0.md#platform-support)
 
 ## Supported Platforms
 


### PR DESCRIPTION
The "master" branch on https://github.com/dotnet/standard does not exist anymore.
Github redirects that link to the current default branch "archive".
But since the expected file does not exist on that branch, users are faced with a 404 page.
Link to the "release/3.0" branch instead, which seems to have the latest version of the document.