### PR TITLE
Update setting-up-your-developer-environment-for-android.md

### DIFF
--- a/tutorials/developing-for-mobile/android/setting-up-your-developer-environment-for-android.md
+++ b/tutorials/developing-for-mobile/android/setting-up-your-developer-environment-for-android.md
@@ -13,7 +13,7 @@ dotnet workload install android
 {% hint style="info" %}
 You may need to run the command with `sudo`\
 \
-You may also need to uninstall old versions. `dotnet workload remove ios`
+You may also need to uninstall old versions. `dotnet workload remove android`
 {% endhint %}
 
 ### Install the Android SDK


### PR DESCRIPTION
The Android guide accidently had a hint for iOS.
  `dotnet workload remove ios`
Changed that to android.