### PR TITLE
Removing the marketing blurb from the welcome page.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # 👋 Welcome
 
-## Welcome
-
-Welcome to Avalonia Docs! 
+Welcome to **Avalonia Docs**! 
 
 Learn how to create .NET GUI applications for Windows, macOS, Linux, iOS, Android and Web Assembly from a single codebase. 
 

--- a/README.md
+++ b/README.md
@@ -2,40 +2,9 @@
 
 ## Welcome
 
-Welcome to Avalonia - the best open source, easy to learn, .NET C# multiplatform package for desktop GUI development (Windows, Mac and Linux).
+Welcome to Avalonia Docs! 
 
-* Avalonia is under rapid development by [a large group of open source contributors](https://github.com/AvaloniaUI/Avalonia/graphs/contributors).
-* Avalonia is [100% open source - and will continue as an open source project](https://github.com/AvaloniaUI/Avalonia), has constantly expanding documentation and a large number of open source samples showing how to use it.
-* Avalonia has [free support on Avalonia Gitter](https://gitter.im/AvaloniaUI/Avalonia), one can also post questions on [Avalonia Github Discussions](https://github.com/AvaloniaUI/Avalonia/discussions). If you're in need of more support you can opt for a [paid support plan](https://avaloniaui.net/support.html) which helps support the continued growth of the project.
-* Avalonia has Visual Studio and Rider support for creating XAML files while having advantage of XAML IntelliSense. Visual Studio also has a visual preview.
-* Avalonia has a tool that facilitate the visual development and debugging called [DevTools](docs/getting-started/developer-tools.md). This tool is also multiplatform - meaning you can use it on Mac and Linux and completely open source.
-
-If you're familiar with WPF or UWP then you should feel right at home with Avalonia. Although Avalonia is not API compatible with either of these frameworks (and so controls can't be used without porting), there's a lot of similarity. If you're a WPF user we have a [page which describes the main differences between WPF and Avalonia](misc/wpf/).
-
-## Why Choose Avalonia?
-
-* Avalonia allows creating applications that look and behave the same on most popular Desktop platforms (Windows, Mac, various flavors of Linux) while also allowing platform specific customizations.
-* Avalonia can be used with your favourite Model-View frameworks.
-* Avalonia is supported by the following companies:
-
-[![](.gitbook/assets/se.png)](https://www.se.com/us/en/) [![](<.gitbook/assets/jblogo (2).png>)](https://www.jetbrains.com) [![](.gitbook/assets/unitylogo.png)](https://unity.com) [![](.gitbook/assets/logo\_thales\_500.png)](https://www.thalesgroup.com) [![](.gitbook/assets/synergy-logo.png)](https://synergysports.com) [![](.gitbook/assets/gritworld-logo.png)](https://en.gritworld.com) [![](.gitbook/assets/wasabi-wallet-logo.svg)](https://www.wasabiwallet.io) [![](.gitbook/assets/mailbird-logo.png)](https://www.getmailbird.com)
-
-and many other smaller companies.
-
-* Avalonia (just like WPF and Silverlight) is fully compositional: you can create a button out of Avalonia primitives in a fashion similar to creating a complex page, while its competitors packages (Web, Xamarin and Java) are not compositional to the same degree.
-* Avalonia UI, unlike JavaScript has full advantage of a strongly typed language. Also Avalonia has full advantage of a compiled-to-binary code language.
-*   Avalonia is an open source multiplatform descendant of great Microsoft packages (WPF and Silverlight) which brought the UI development on a completely new level, creating a set of new concepts which allow to create a full blown UI application in a fraction of the time and effort compared to other technologies. Here is the list of some of the concepts:
-
-    * Visual and Logical Trees
-    * Attached or Dependency Properties which can be defined outside of the object on which they are used and do not take any extra memory unless they are assigned a non-default value and have a special event to fire when their values change.
-    * Attached Routed Events that can be defined outside of the objects that fire them and can propagate and be handled up and down on the trees.
-    * Bindings and the related MVVM pattern
-    * Control Templates
-    * Data Templates
-    * Styles
-    * Behaviors provide way to modify and augment the behavior of a C# class without modifying the class itself by using the events.
-
-    All these paradigms have been implemented for multiple platforms in Avalonia.
+Learn how to create .NET GUI applications for Windows, macOS, Linux, iOS, Android and Web Assembly from a single codebase. 
 
 ## Supported .NET Version
 
@@ -63,3 +32,13 @@ The following environments support Avalonia XAML with IntelliSense:
 [Installing Avalonia Extension for Visual Studio](docs/getting-started/ide-support/)
 
 [JetBrains Rider Setup](docs/getting-started/ide-support/jetbrains-rider-setup.md)
+
+## How to get help
+
+### Community Support 
+If you've found a bug or issue in the framework, you should create an issue on [GitHub](https://github.com/AvaloniaUI/Avalonia). 
+
+If you're looking for help with your app, try engaging our active developer community on [Telegram](https://t.me/Avalonia). 
+
+### Commerical Support 
+We have a range of commercial support plans that provide priority assistance from the core contributors. You can learn more from [our website](https://avaloniaui.net/support.html). 


### PR DESCRIPTION
I'd like to keep docs focused on helping developers rather than convincing them.