### PR TITLE
Added unhandled exception handling to Summary

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -17,6 +17,7 @@
   * [Assets](docs/getting-started/assets.md)
   * [Developer Tools](docs/getting-started/developer-tools.md)
   * [Logging Errors and Warnings](docs/getting-started/logging-errors-and-warnings.md)
+  * [Unhandled Exceptions](docs/getting-started/UnhandledExceptions.md)
 * [🔄 Data Binding](docs/data-binding/README.md)
   * [The DataContext](docs/data-binding/the-datacontext.md)
   * [Change Notifications](docs/data-binding/change-notifications.md)


### PR DESCRIPTION
The page was missing in the sumnmary, so it was not accessible. This PR should fix it.