### PR TITLE
Document StringFormat parameter of Binding

### DIFF
--- a/docs/data-binding/bindings.md
+++ b/docs/data-binding/bindings.md
@@ -58,3 +58,26 @@ The available binding modes are:
 
 The `Default` mode is assumed if one is not specified. This mode is generally `OneWay` for control properties that do not change due to user input \(e.g. `TextBlock.Text`\) and `TwoWay` for control properties that _do_ change due to user input \(e.g. `TextBox.Text`\).
 
+## String Formatting <a id="binding-stringformat"></a>
+
+You can apply a format string to the binding to influence how the value is represented in the UI:
+
+```markup
+<TextBlock Text="{Binding FloatValue, StringFormat=\{0.0\}}" />
+```
+
+When a `StringFormat` parameter is present, the value of the binding will be converted using the `StringFormatValueConverter` which will be passed the format string.
+
+The format string is specified slightly different than in WPF, note the additional escaped curly braces:
+
+**WPF:**
+
+```markup
+<TextBlock Text="{Binding FloatValue, StringFormat=0.0}" />
+```
+
+**Avalonia:**
+
+```markup
+<TextBlock Text="{Binding FloatValue, StringFormat=\{0.0\}}" />
+```


### PR DESCRIPTION
After scratching my head for a bit why the result of my bindings would always show `0` when using `StringFormat` I found out that the _format_ of the `StringFormat` is different from WPF.

This PR documents both `StringFormat` and how it differs from WPF.

I could make a PR to change `StringFormatValueConverter` to support both cases if that's something that's useful to have.