### PR TITLE
(Android) Add tutorials for physical device deployment & VSCode debugging setup for Linux

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -200,6 +200,8 @@
   * [Android](tutorials/developing-for-mobile/android/README.md)
     * [Setting up your developer environment for Android](tutorials/developing-for-mobile/android/setting-up-your-developer-environment-for-android.md)
     * [Build and run your Application on a Simulator](tutorials/developing-for-mobile/android/build-and-run-your-application-on-a-simulator.md)
+    * [Build and run your Application on a physical device](tutorials/developing-for-mobile/android/build-and-run-your-application-on-a-device.md)
+    * [Configure debugging in Visual Studio Code (Linux)](tutorials/developing-for-mobile/android/configure-vscode-debug-linux.md)
   * [iOS](tutorials/developing-for-mobile/ios/README.md)
     * [Setting up your developer environment for iOS](tutorials/developing-for-mobile/ios/setting-up-your-developer-environment-for-ios.md)
     * [Build and run your application on a Simulator](tutorials/developing-for-mobile/ios/build-and-run-your-application-on-a-simulator.md)

--- a/tutorials/developing-for-mobile/android/build-and-run-your-application-on-a-device.md
+++ b/tutorials/developing-for-mobile/android/build-and-run-your-application-on-a-device.md
@@ -1,0 +1,33 @@
+# Build and run your Application on a physical device
+
+To deploy and run the Application on a real Android device, make sure of the following:
+
+1. Have the Android version on the device match the supported or target versions in AndroidManifest.xml (if no versions are specified, assume that target version is latest, supported by Xamarin/MAUI),
+2. Connect the device to development machine and enable USB Debugging in developer settings,
+3. If default connection mode is "battery charging only", switch to MTP or another mode (otherwise ADB won't connect to the device),
+4. Have matching Android SDK installed to the target SDK version in AndroidManifest.xml,
+
+Deployment is done via running the `dotnet run` command (if using console), or via the following setup (if using Visual Studio Code):
+
+tasks.json:
+```json
+{
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"label": "build-android",
+			"command": "dotnet",
+			"type": "process",
+			"args": [
+				"build",
+				"--no-restore",
+				"${workspaceFolder}/<ProjectName>.csproj",
+				"-p:TargetFramework=net6.0-android",
+				"-p:Configuration=Debug"
+			],
+			"problemMatcher": "$msCompile"
+		}
+	]
+}
+```
+where `<ProjectName>` is your Android-specific Avalonia project name.

--- a/tutorials/developing-for-mobile/android/configure-vscode-debug-linux.md
+++ b/tutorials/developing-for-mobile/android/configure-vscode-debug-linux.md
@@ -17,15 +17,15 @@ For debugging Avalonia-based Android projects on Linux (using Visual Studio Code
 			"type": "mono",
 			"preLaunchTask": "run-debug-android",
 			"request": "attach",
-      "address": "localhost",
-      "port": 10000
+      			"address": "localhost",
+      			"port": 10000
 		},
 		{
 			"name": "Attach - Android",
 			"type": "mono",
-      "request": "attach",
-      "address": "localhost",
-       "port": 10000
+			"request": "attach",
+			"address": "localhost",
+			"port": 10000
 		}
 	]
 }

--- a/tutorials/developing-for-mobile/android/configure-vscode-debug-linux.md
+++ b/tutorials/developing-for-mobile/android/configure-vscode-debug-linux.md
@@ -1,0 +1,67 @@
+# Configure debugging in Visual Studio Code (Linux)
+
+For debugging Avalonia-based Android projects on Linux (using Visual Studio Code), follow the steps:
+
+1. Make sure to install the "Mono Debug" extension
+
+{% embed url="https://marketplace.visualstudio.com/items?itemName=ms-vscode.mono-debug" %}
+
+2. Configure your `launch.json` file to include the following entries (for deploy + debug, and attach respectively):
+
+```json
+{
+	"version": "0.2.0",
+	"configurations": [
+		{
+			"name": "Debug - Android",
+			"type": "mono",
+			"preLaunchTask": "run-debug-android",
+			"request": "attach",
+      "address": "localhost",
+      "port": 10000
+		},
+		{
+			"name": "Attach - Android",
+			"type": "mono",
+      "request": "attach",
+      "address": "localhost",
+       "port": 10000
+		}
+	]
+}
+```
+where `port` value can be arbitrary (make sure it's not used already by other applications or OS).
+
+3. Add a new entry to `tasks.json` for deploying to Android (device or emulator) with enabled Mono debug server:
+
+```json
+{
+	"version": "2.0.0",
+	"tasks": [
+		/* ... */
+		{
+			"label": "run-debug-android",
+			"command": "dotnet",
+			"type": "shell",
+			"args": [
+				"build",
+				"--no-restore",
+				"-t:Run",
+				"${workspaceFolder}/<ProjectName>.Android.csproj",
+				"-p:TargetFramework=net6.0-android",
+				"-p:Configuration=Debug",
+				"-p:AndroidAttachDebugger=true",
+				"-p:AndroidSdbHostPort=10000"
+			],
+			"problemMatcher": "$msCompile"
+		}
+	]
+}
+```
+where `<ProjectName>` is your Android-specific Avalonia project name.
+
+{% hint style="warn" %}
+Make sure that the value of `port` variable in `launch.json` matches the one of `AndroidSdbHostPort` in `tasks.json`, otherwise the debugger won't be able to connect.
+{% endhint %}
+
+After the setup, you can run the `Debug - Android` task via the Debug panel. Dotnet runtime will build and deploy the app, and Mono debugger will connect to the open port on the device, with all standard debugging functionality available.


### PR DESCRIPTION
Haven't tested the debugging setup extensively yet, but should work on Ubuntu and derivatives, I think.
Tested on Lubuntu 20.04.