### PR TITLE
Update add-and-layout-controls.md

### DIFF
--- a/tutorials/music-store-app/add-and-layout-controls.md
+++ b/tutorials/music-store-app/add-and-layout-controls.md
@@ -28,9 +28,19 @@ If you remember earlier in the section about MVVM we discussed how `Views` use `
 
 This `Binding Expression` is saying, when the button is `clicked`, then `execute` the `command` called `BuyMusicCommand` on the ViewModel.
 
-Open `MainWindowViewModel.cs` and add the following code:
+Open `MainWindowViewModel.cs` and add the following code (the `ICommand` Interface requires `System.Windows.Input` but you'll need the additional namespaces, specified at the top, later on in the tutorial):
 
 ```csharp
+using System;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Reactive.Concurrency;
+using System.Reactive.Linq;
+using System.Windows.Input;
+using ReactiveUI;
+
+namespace Avalonia.MusicStore.ViewModels
+
 public class MainWindowViewModel : ViewModelBase
     {
         public MainWindowViewModel()


### PR DESCRIPTION
The original tutorial page instructs the user to open `MainWindowViewModel.cs` and add some code including `public ICommand BuyMusicCommand { get; }`.  `ICommand` is provided by `System.Windows.Input` which is listed in the downloadable Github example code but isn't listed in the the tutorial.  Because of this, if you follow the tutorial to this point, it won't build.

This update adds the required `System.Windows.Input` namespace as well as the rest of the namespaces listed at the top of `MainWindowViewModel.cs` on Github at https://github.com/AvaloniaUI/Avalonia.MusicStore/blob/master/Avalonia.MusicStore/ViewModels/MainWindowViewModel.cs