### PR TITLE
Update running-on-raspbian-lite-via-drm.md

### DIFF
--- a/guides/deep-dives/running-on-raspbian-lite-via-drm.md
+++ b/guides/deep-dives/running-on-raspbian-lite-via-drm.md
@@ -114,7 +114,7 @@ Now create a new UserControl with name `MainSingleView` and host the `MainView`:
              d:DesignHeight="450"
              x:Class="AvaloniaRaspbianLiteDrm.MainSingleView">
     <avaloniaRaspbianLiteDrm:MainView />
-</UserControl
+</UserControl>
 ```
 
 Also change the `MainWindow.axaml` to host the `MainView` inside:


### PR DESCRIPTION
noticed the closing `>` in `</UserControl>` was missing when I was copying and pasting the example for `MainSingleView`