### PR TITLE
Showing how to use attached properties in selectors

### DIFF
--- a/docs/styling/selectors.md
+++ b/docs/styling/selectors.md
@@ -140,11 +140,11 @@ new Style(x => x.OfType<Button>().PropertyEquals(Button.IsDefaultProperty, true)
 
 Matches any control which has the specified property set to the specified value.
 
-**Note:** When using a `AttachedProperty` in Selectors inside XAML, it has to be wrapped in braces.
-
-```markup
-<Style Selector="TextBlock[(Grid.Row)=0]">
-```
+> **Note:** When using a `AttachedProperty` in Selectors inside XAML, it has to be wrapped in braces.
+>
+> ```markup
+> <Style Selector="TextBlock[(Grid.Row)=0]">
+> ```
 
 ## Template <a id="template"></a>
 

--- a/docs/styling/selectors.md
+++ b/docs/styling/selectors.md
@@ -140,6 +140,12 @@ new Style(x => x.OfType<Button>().PropertyEquals(Button.IsDefaultProperty, true)
 
 Matches any control which has the specified property set to the specified value.
 
+**Note:** When using a `AttachedProperty` in Selectors inside XAML, it has to be wrapped in braces.
+
+```markup
+<Style Selector="TextBlock[(Grid.Row)=0]">
+```
+
 ## Template <a id="template"></a>
 
 {% tabs %}


### PR DESCRIPTION
This adds a note to the **PropertyEquals** section of the Selector page, showing how to use attached properties inside selectors. I think that is valuable information to show here, because it is not really obvious how to do it, e.g. I had tried many different approaches and only found out by googeling.