### PR TITLE
Two tiny doc changes

### DIFF
--- a/tutorials/music-store-app/displaying-images.md
+++ b/tutorials/music-store-app/displaying-images.md
@@ -97,6 +97,12 @@ Calling this asynchronous method will iterate through each item in a copy of the
 
 Notice a `CancellationToken` is used to check if we want to stop loading album covers.
 
+Add this field to `MusicStoreViewModel`
+
+```csharp
+private CancellationTokenSource? _cancellationTokenSource;
+```
+
 Now add the following code to the beginning of `DoSearch` method of `MusicStoreViewModel` after the `SearchResults.Clear();` line.
 
 ```csharp

--- a/tutorials/music-store-app/load-data-at-startup.md
+++ b/tutorials/music-store-app/load-data-at-startup.md
@@ -29,6 +29,8 @@ Register it in the constructor of the same class like:
 RxApp.MainThreadScheduler.Schedule(LoadAlbums);
 ```
 
+If you get an error about "Cannot resolve method Schedule", you may be missing the line `using System.Reactive.Concurrency;` in `MainWindowViewModel`'s using section.
+
 As you can see it firstly uses the business logic apis to load the list of `Albums`. It then transforms each one into an `AlbumViewModel`. After this we add each `AlbumViewModel` instance to the `ObservableCollection` of `Albums`, this will instantly update the UI.
 
 Note we then re-iterate over the `Albums` and asynchronously load each cover. Note that we do this after adding all the albums to the list, as its more important to quickly show the user all the albums available and then load the images.


### PR DESCRIPTION
Two tiny changes after working my way through the music store tutorial:

* Add the `CancellationTokenSource` field to `MusicStoreViewModel`
* And I deleted the `System.Reactive.Concurrency` using statement, so was stumped a bit when I got an error with `RxApp.MainThreadScheduler.Schedule(LoadAlbums);`