### PR TITLE
docs: many Mac related grammar corrections

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Avalonia is supported on the following platforms:
 
 * Windows 8 and higher
   * **Note**: Avalonia works correctly on Windows 7 also, but not supported _officially_
-* MacOS High Sierra 10.13 and higher
+* macOS High Sierra 10.13 and higher
 * for Linux:
   * Debian 9 (Stretch) and higher
   * Ubuntu 16.04 and higher

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -174,7 +174,7 @@
   * [Comparison of Avalonia with WPF and UWP](guides/developer-guides/comparison-of-avalonia-with-wpf-and-uwp.md)
   * [Debugging Previewer](guides/developer-guides/debugging-previewer.md)
   * [Debugging the XAML compiler](guides/developer-guides/debugging-xamlil.md)
-  * [MacOS Development](guides/developer-guides/macos-development.md)
+  * [macOS Development](guides/developer-guides/macos-development.md)
   * [Release Process](guides/developer-guides/release-process.md)
   * [Maintaining Stable Branch](guides/developer-guides/maintaining-stable-branch-pr-merge-process.md)
 

--- a/docs/distribution-publishing/macos.md
+++ b/docs/distribution-publishing/macos.md
@@ -344,7 +344,7 @@ You need a lot of things:
 * In KeyChain you should see this certificates `3rd Party Mac Developer Installer` and `Apple Distribution`. If cert names are started with another strings - you've created a wrong certificate. Try again.
 * Expand imported keys in KeyChain and double click on a private key inside.
 * Go to Access Control Tab.
-* Select `Allow all applications to access this item` in case you don't want to enter a mac profile password for every file sign.
+* Select `Allow all applications to access this item` in case you don't want to enter a Mac profile password for every file sign.
 
 ### Sandbox and bundle <a id="sandbox-and-bundle"></a>
 
@@ -569,7 +569,7 @@ As Apple requires multi-factor authentication (MFA) on developer accounts, `nota
 xcrun notarytool store-credentials "AC_PASSWORD" --apple-id "${{ secrets.APPLE_ID }}" --team-id ${{ env.TEAM_ID }} --password "${{ secrets.NOTARY_TOOL_PASSWORD }}"
 ```
 
-`TEAM_ID` is the team id in AppStore Connect, `APPLE_ID` is your Apple account e-mail address, `NOTARY_TOOL_PASSWORD` is the app-password you generated.
+`TEAM_ID` is the team id in App Store Connect, `APPLE_ID` is your Apple account e-mail address, `NOTARY_TOOL_PASSWORD` is the app-password you generated.
 
 To use these steps in your GitHub Actions workflow add them as a step to the job that builds your app:
 

--- a/guides/developer-guides/build-avalonia-from-source.md
+++ b/guides/developer-guides/build-avalonia-from-source.md
@@ -54,7 +54,7 @@ dotnet run
 Open Avalonia.sln in Visual Studios 2019 or above.
 ```
 
-### OSX
+### macOS
 
 The native interop layer requires code generation, this can be triggered by:
 `./build.sh --target CompileNative`

--- a/guides/developer-guides/macos-development.md
+++ b/guides/developer-guides/macos-development.md
@@ -1,12 +1,12 @@
 ---
-description: Getting started developing for the MacOS backend
+description: Getting started developing for the macOS backend
 ---
 
-# MacOS Development
+# macOS Development
 
 ## Native code
 
-The native OSX code is located at `native/Avalonia.Native/src/OSX`. Open the `Avalonia.Native.OSX.xcodeproj` project in Xcode.
+The native macOS code is located at `native/Avalonia.Native/src/OSX`. Open the `Avalonia.Native.OSX.xcodeproj` project in Xcode.
 
 You can make changes in Xcode and compile using Cmd+B. You will then need to point your Avalonia application to the modified dynlib. The path can be found by clicking on the dylib in Xcode’s project navigator under Products.
 
@@ -19,11 +19,11 @@ You then specify this path in your AppBuilder using:
 })
 ```
 
-If you're running on an M1 Mac and targeting .NET 5 and lower then you'll need to switch to rosetta by selecting "My Mac \(Rosetta\)" in the toolbar.
+If you're running on an Apple Silicon Mac and targeting .NET 5 and lower then you'll need to switch to rosetta by selecting "My Mac \(Rosetta\)" in the toolbar.
 
 ### Bundling Dev Code
 
-In certain situations you need to run an Avalonia sample application as an app bundle. One of these situations is testing MacOS Accessibility - Xcode's Accessibility Inspector fails to recognise the application otherwise.
+In certain situations you need to run an Avalonia sample application as an app bundle. One of these situations is testing macOS Accessibility - Xcode's Accessibility Inspector fails to recognise the application otherwise.
 
 A solution to this is to change the sample's output path to [resemble an app bundle](https://developer.apple.com/library/archive/documentation/CoreFoundation/Conceptual/CFBundles/BundleTypes/BundleTypes.html). You can do this by modifying the output path in the csproj, e.g.:
 

--- a/misc/projects-that-are-using-avalonia.md
+++ b/misc/projects-that-are-using-avalonia.md
@@ -40,7 +40,7 @@ The Avalonia port of ILSpy
 
 ## [Jaya File Manager (JayaFM)](https://github.com/nullvoid-creations/Jaya)
 
-**JayaFM** is a small .NET Core based cross platform file explorer application which runs on Windows, Mac and Linux. Its goal is very simple, _"To allow browsing and managing of several file systems and cloud storage accounts simultaneously using a one application which should work and look similar on all platforms it supports."_.
+**JayaFM** is a small .NET Core based cross platform file explorer application which runs on Windows, macOS and Linux. Its goal is very simple, _"To allow browsing and managing of several file systems and cloud storage accounts simultaneously using a one application which should work and look similar on all platforms it supports."_.
 
 Application is designed to be plug-able from the ground up i.e. anyone with experience of working with .NET Framework will be able to add support for new storage services by implementing a simple plugin.
 

--- a/tutorials/developing-for-mobile/android/setting-up-your-developer-environment-for-android.md
+++ b/tutorials/developing-for-mobile/android/setting-up-your-developer-environment-for-android.md
@@ -20,7 +20,7 @@ You may also need to uninstall old versions. `dotnet workload remove android`
 
 There are a few ways to install the Android SDK.
 
-If you have Visual Studio or Visual for Mac you should follow the guide found here:
+If you have Visual Studio or Visual Studio for Mac you should follow the guide found here:
 
 {% embed url="https://docs.microsoft.com/en-us/xamarin/android/get-started/installation/android-sdk" %}
 

--- a/tutorials/developing-for-mobile/create-a-cross-platform-solution.md
+++ b/tutorials/developing-for-mobile/create-a-cross-platform-solution.md
@@ -37,7 +37,7 @@ This will create a project with the following structure:
 
 * HelloWorld (Avalonia UI project with Views and ViewModels)
 * HelloWorld.Android (Avalonia bootstrap code for Android)
-* HelloWorld.Desktop (Avalonia bootstrap code for Desktop - Window, MacOS and Linux)
+* HelloWorld.Desktop (Avalonia bootstrap code for Desktop - Windows, macOS and Linux)
 * HelloWorld.iOS (Avalonia bootstrap code for iOS)
 * HelloWorld.Web (Avalonia bootstrap code for Web)
 * nuget.config (gives access to nightly builds of Avalonia)

--- a/tutorials/developing-for-mobile/ios/README.md
+++ b/tutorials/developing-for-mobile/ios/README.md
@@ -4,12 +4,12 @@ description: How to develop for iOS
 
 # iOS
 
-In this section we describe how to setup you machine for iOS development. Then if you have a mac how to run it on a simulator or an actual iPhone or iPad.
+In this section we describe how to setup you machine for iOS development. Then, if you have a Mac, how to run it on a simulator or an actual iPhone or iPad.
 
 {% hint style="info" %}
-Due to Apple's policies it is unfortunately not possible to run the iOS simulators or test on an iPhone or iPad without a genuine Apple device running MacOS and XCode.\
+Due to Apple's policies it is unfortunately not possible to run the iOS simulators or test on an iPhone or iPad without a genuine Apple device running macOS and Xcode.\
 \
-We hope this might change in the future, if you do not have access to MacOS a  workaround is to run your application in a Window sized appropriately. Or follow the guides on Android.\
+We hope this might change in the future, if you do not have access to a Mac, a workaround is to run your application in a Window sized appropriately. Or follow the guides on Android.\
 \
 You should always test on a real device before releasing.
 {% endhint %}

--- a/tutorials/developing-for-mobile/ios/build-and-run-your-application-on-your-iphone-or-ipad.md
+++ b/tutorials/developing-for-mobile/ios/build-and-run-your-application-on-your-iphone-or-ipad.md
@@ -1,18 +1,18 @@
 # Build and Run your Application on your iPhone or iPad
 
-In order to allow dotnet to sideload your application to your iphone or ipad you must first use XCode to provision your device.
+In order to allow dotnet to sideload your application to your iphone or ipad you must first use Xcode to provision your device.
 
 Before continuing follow this guide to create a free Apple developer signing certificate.
 
 {% embed url="https://docs.microsoft.com/en-us/xamarin/ios/get-started/installation/device-provisioning/free-provisioning" %}
 
-This has to be done by creating an XCode app project that has the same `bundle identifier` that you will use in your application.
+This has to be done by creating an Xcode app project that has the same `bundle identifier` that you will use in your application.
 
-1. Open XCode
+1. Open Xcode
 
 ![](<../../../.gitbook/assets/Screenshot 2022-03-17 at 12.09.54.png>)
 
-2\. Select Create a new XCode project
+2\. Select Create a new Xcode project
 
 ![](<../../../.gitbook/assets/image (36).png>)
 
@@ -32,7 +32,7 @@ This has to be done by creating an XCode app project that has the same `bundle i
 
 ![](<../../../.gitbook/assets/image (32).png>)
 
-8\. Click on devices and connect your iPhone or iPad with the USB cable. XCode will start to provision your phone for development.
+8\. Click on devices and connect your iPhone or iPad with the USB cable. Xcode will start to provision your phone for development.
 
 ![](<../../../.gitbook/assets/Screenshot 2022-03-17 at 12.19.06.png>)
 
@@ -44,7 +44,7 @@ This has to be done by creating an XCode app project that has the same `bundle i
 
 If successful you may return to your IDE of choice and open the `info.plist` file from the iOS project.
 
-11\. Change the bundle identifier to the same as the one you choose in XCode in step 3.
+11\. Change the bundle identifier to the same as the one you choose in Xcode in step 3.
 
 ![](<../../../.gitbook/assets/image (18).png>)
 

--- a/tutorials/developing-for-mobile/ios/setting-up-your-developer-environment-for-ios.md
+++ b/tutorials/developing-for-mobile/ios/setting-up-your-developer-environment-for-ios.md
@@ -2,7 +2,7 @@
 
 ### Prerequisites&#x20;
 
-On a mac you will need to have the latest version of MacOS and XCode installed.
+On a Mac you will need to have the latest version of acOS and Xcode installed.
 
 ### Install the SDK
 
@@ -20,4 +20,4 @@ You may need to run the command with `sudo`\
 You may also need to uninstall old versions. `dotnet workload remove ios`
 {% endhint %}
 
-This will allow you to build applications for iOS on any platform. However you will only be able to test and run them if you have access to actual MacOS hardware with XCode installed.
+This will allow you to build applications for iOS on any platform. However you will only be able to test and run them if you have access to actual macOS hardware with Xcode installed.

--- a/tutorials/music-store-app/README.md
+++ b/tutorials/music-store-app/README.md
@@ -12,7 +12,7 @@ It was created by [Dan Walmsley ](https://twitter.com/dwuk86)for a [webinar ](ht
 
 In this tutorial, you will see just how easy it is to build great looking visual desktop applications using Avalonia.
 
-This guide has instructions for Rider on OSX, however the steps will be almost the same on other operating systems, and reasonably similar on other IDEs such as Visual Studio.
+This guide has instructions for Rider on macOS, however the steps will be almost the same on other operating systems, and reasonably similar on other IDEs such as Visual Studio.
 
 Our livestream assumes some knowledge of [XAML](../../guides/basics/introduction-to-xaml.md), [MVVM ](../../guides/basics/mvvm.md)development, however this guide should fill in the gaps for beginners.
 

--- a/tutorials/music-store-app/setup-development-environment.md
+++ b/tutorials/music-store-app/setup-development-environment.md
@@ -32,7 +32,7 @@ Examples:
 
 1. Download and install [Rider: The Cross-Platform .NET IDE from JetBrains](https://www.jetbrains.com/rider/)
 
-   Rider will give you the very best development experience available for Avalonia. It is available for Windows, Linux and Mac
+   Rider will give you the very best development experience available for Avalonia. It is available for Windows, Linux and macOS
 
 2. Install the Avalonia Plugin
 


### PR DESCRIPTION
Naming / Casing / Grammatical corrections, not limited to:

Xcode casing

OSX -> macOS references

macOS casing (docs only, code namings not changed)

mac -> Mac casing (docs only, code namings not changed)

App Store Connect casing

M1 references -> Apple Silicon (now that there is M2 and beyond)


Misc:

Window -> Windows

Visual for Mac -> Visual Studio for Mac

other misc. grammatical improvements

🙂