### PR TITLE
Fix syntax issue in class-handlers.md

### DIFF
--- a/misc/wpf/class-handlers.md
+++ b/misc/wpf/class-handlers.md
@@ -20,15 +20,15 @@ private static void HandleMyEvent(object sender, RoutedEventArgs e)
 ```csharp
 static MyControl()
 {
-    MyEvent.AddClassHandler<MyControl>(x => x.HandleMyEvent);
+    MyEvent.AddClassHandler<MyControl>((x, e) => x.HandleMyEvent(e));
 }
 
-private void HandleMyEvent(object sender, RoutedEventArgs e)
+private void HandleMyEvent(RoutedEventArgs e)
 {
 }
 ```
 {% endtab %}
 {% endtabs %}
 
-Notice that in WPF you have to add the class handler as a static method, whereas in Avalonia the class handler is not static: the notification is automatically directed to the correct instance.
+Notice that in WPF you have to add the class handler as a static method, whereas in Avalonia the class handler is not static: the notification is automatically directed to the correct instance. The `sender` parameter typical of event handlers is not necessary in this case and everything remains strongly typed.
 


### PR DESCRIPTION
Fixes syntax issue for Avalonia class handler. Add remark about strong typing.

**Scope of this PR:**
- [X] fix or update to an existing page
- [ ] add a new page to the docs

**In any case**
- [X] Spell-checking done
- [X] Checked if all hyperlinks work
- [X] Checked if all images are visible

## Fixed issues
Fixes #355 
