### PR TITLE
Revert "Removed duplicate closing tag '>'"

### DIFF
--- a/tutorials/todo-list-app/wiring-up-the-views.md
+++ b/tutorials/todo-list-app/wiring-up-the-views.md
@@ -15,7 +15,7 @@ Views/MainWindow.axaml
         Icon="/Assets/avalonia-logo.ico"
         Width="200" Height="300"
         Title="Avalonia Todo"
-        Content="{Binding List}"
+        Content="{Binding List}">
 </Window>
 ```
 


### PR DESCRIPTION
As [noticed by @neilseller](https://github.com/AvaloniaUI/Documentation/commit/0f7aa2865340bdb2223bc91f1d993e0095016849#commitcomment-94610774) previous PR was merged by mistake.
Original code was valid.