### PR TITLE
Improved consistency and intuitivity altering classname in example @ styles.md 

### DIFF
--- a/docs/styling/styles.md
+++ b/docs/styling/styles.md
@@ -65,9 +65,9 @@ As in CSS, controls can be given _style classes_ which can be used in selectors.
 <Button Classes="h1 blue"/>
 ```
 
-If you need to add or remove class by condition, you can use following special syntax:
+If you need to add or remove class by condition, you can use the following special syntax:
 ```markup
-<Button Classes.accent="{Binding IsSpecial}" />
+<Button Classes.blue="{Binding IsSpecial}" />
 ```
 
 Style classes can also be manipulated in code using the `Classes` collection:


### PR DESCRIPTION
made the example classnames on the page consistent/intuitive (every example on the page uses "blue" now, before: "accent" for the class-conditional binding special-syntax [also bad classname in the docs of a UI-Framework, especially at a position where you introduce a new Syntax, due to the many other usages of that word regarding UI]

## What does the pull request do?
<!--- Give a bit of background on the PR here. -->

**Scope of this PR:**
- [x] fix or update to an existing page
- [ ] add a new page to the docs

## Checklist
<!-- Please fill out the checklist below.  -->

**If this is a new Page**
- [ ] Added the new page to [Summary.md](https://docs.gitbook.com/getting-started/git-sync/content-configuration#summary)

**In any case**
- [x] Spell-checking done
- [x] Checked if all hyperlinks work
- [x] Checked if all images are visible

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
