### PR TITLE
Fix example AttachedProperty using a local function that does not create equal delegates

### DIFF
--- a/docs/data-binding/creating-and-binding-attached-properties.md
+++ b/docs/data-binding/creating-and-binding-attached-properties.md
@@ -64,13 +64,17 @@ public class DoubleTappedBehav : AvaloniaObject
         }
 
         // local handler fcn
-        void Handler(object s, RoutedEventArgs e)
+        static void Handler(object s, RoutedEventArgs e)
         {
-            // This is how we get the parameter off of the gui element.
-            object commandParameter = interactElem.GetValue(CommandParameterProperty);
-            if (commandValue?.CanExecute(commandParameter) == true)
+            if (s is Interactive interactElem)
             {
-                commandValue.Execute(commandParameter);
+                // This is how we get the parameter off of the gui element.
+                object commandParameter = interactElem.GetValue(CommandParameterProperty);
+                ICommand commandValue = interactElem.GetValue(CommandProperty);
+                if (commandValue?.CanExecute(commandParameter) == true)
+                {
+                    commandValue.Execute(commandParameter);
+                }
             }
         }
     }


### PR DESCRIPTION
Unfortunately this took me quite a bit to work out, I was using the example code for my own AttachedProperty command and every time I opened the drop-down all the items were reinitialized and the handlers only added but not removed.

Local functions using local variables cannot create equal delegates, therefore, [this equality check](https://github.com/AvaloniaUI/Avalonia/blob/033c1e29ce83ff1aba878d027ab892453c5bc364/src/Avalonia.Base/Interactivity/Interactive.cs#L90) when removing fails.
Using a local function that can create equal delegates, i.e. that does not reference local variables fixes the issue.

## What does the pull request do?
Fix/Improve the example code of the attached property event handler

**Scope of this PR:**
- [x] fix or update to an existing page
- [ ] add a new page to the docs

## Checklist
<!-- Please fill out the checklist below.  -->

**If this is a new Page**
- [ ] Added the new page to [Summary.md](https://docs.gitbook.com/getting-started/git-sync/content-configuration#summary)

**In any case**
- [x] Spell-checking done
- [x] Checked if all hyperlinks work
- [x] Checked if all images are visible

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
