### PR TITLE
Remove add Repo step in Rider Setup

### DIFF
--- a/docs/getting-started/ide-support/jetbrains-rider-setup.md
+++ b/docs/getting-started/ide-support/jetbrains-rider-setup.md
@@ -48,11 +48,7 @@ A new Preferences Screen will open up. Click the `Settings` icon as shown and se
 
 ![configure-plugin-repos](<../../../.gitbook/assets/jetbrains-rider-setup-2-configure-plugin-repos.png>)
 
-Click the `+` icon and enter the URL `https://plugins.jetbrains.com/plugins/dev/14839` then click `OK`:
-
-![enter-plugin-repo](<../../../.gitbook/assets/jetbrains-rider-setup-3-enter-plugin-repo.png>)
-
-Now click on the `Marketplace` tab and search for `Avalonia`. Select `AvaloniaRider` and click `Install`; once that's done, click the `Restart IDE` button that appears.
+Now click on the `Marketplace` tab and search for `Avalonia`. Select `AvaloniaRider` and click `Install`; accept the warning about Third-Party Plugins; once that's done, click the `Restart IDE` button that appears.
 
 ![plugin-install](<../../../.gitbook/assets/jetbrains-rider-setup-4-plugin-install.png>)
 


### PR DESCRIPTION
## What does the pull request do?
Removes the out-of-date step instructing the user to add a custom Plugin Repository to Rider.  This is no longer necessary and the Avalonia Plugin can be found directly by searching the Marketplace.

**Scope of this PR:**
- [X] fix or update to an existing page
- [ ] add a new page to the docs

## Checklist
<!-- Please fill out the checklist below.  -->

**If this is a new Page**
- [ ] Added the new page to [Summary.md](https://docs.gitbook.com/getting-started/git-sync/content-configuration#summary)

**In any case**
- [X] Spell-checking done
- [X] Checked if all hyperlinks work
- [X] Checked if all images are visible

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
