### PR TITLE
Remove wrong statement about Cue value

### DIFF
--- a/docs/animations/keyframe-animations.md
+++ b/docs/animations/keyframe-animations.md
@@ -42,7 +42,7 @@ If the selector isn't conditional then the animation will be triggered when a ma
 
 The `KeyFrame` objects defines when the target `Setter` objects should be applied on the target `Control`, with value interpolation in-between.
 
-The `Cue` property of an `KeyFrame` object is based on the `Duration` of the parent animation and can be an absolute time index \(i.e., `"0:0:1"`\) or a percent of the animation's `Duration` \(i.e., `"0%"`, `"100%"`\). However, `Cue`'s value should not exceed the `Duration` specified.
+The `Cue` property of an `KeyFrame` object is based on the `Duration` of the parent animation and is a percent of the animation's `Duration` \(i.e., `"0%"`, `"100%"`\). However, `Cue`'s value should not exceed the `Duration` specified.
 
 All `Animation` objects should contain at least one `KeyFrame`, with a `Setter` that has target property and value.
 

--- a/docs/animations/keyframe-animations.md
+++ b/docs/animations/keyframe-animations.md
@@ -42,7 +42,7 @@ If the selector isn't conditional then the animation will be triggered when a ma
 
 The `KeyFrame` objects defines when the target `Setter` objects should be applied on the target `Control`, with value interpolation in-between.
 
-The `Cue` property of an `KeyFrame` object is based on the `Duration` of the parent animation and is a percent of the animation's `Duration` \(i.e., `"0%"`, `"100%"`\). However, `Cue`'s value should not exceed the `Duration` specified.
+The `Cue` property of an `KeyFrame` object is based on the `Duration` of the parent animation and is a percent of the animation's `Duration` \(i.e., `"0%"`, `"100%"`\).
 
 All `Animation` objects should contain at least one `KeyFrame`, with a `Setter` that has target property and value.
 


### PR DESCRIPTION
## What does the pull request do?
The docs claim the cue is either a absolute duration or a percentage. But actually only the latter ist true.
(See https://github.com/AvaloniaUI/Avalonia/blob/master/src/Avalonia.Base/Animation/Cue.cs#L33-L50)

**Scope of this PR:**
- [x] fix or update to an existing page
- [ ] add a new page to the docs

## Checklist
<!-- Please fill out the checklist below.  -->

**In any case**
- [x] Spell-checking done
- [x] Checked if all hyperlinks work
- [x] Checked if all images are visible