### PR TITLE
Added a warning for `using` XAML namespace syntax

### DIFF
--- a/guides/basics/introduction-to-xaml.md
+++ b/guides/basics/introduction-to-xaml.md
@@ -61,7 +61,7 @@ xmlns:myAlias3="using:My.NameSpace"
 
 {% hint style="info" %} `My.NameSpace` is the namespace in `C#` you want to use. {% endhint %}
 
-{% hint style="warning" %} `using`-syntax cannot be used in case of reflection based type resolution like in `ReflectionBinding`. {% endhint %}
+{% hint style="warning" %} The `using`-syntax cannot be used in case of reflection based type resolution like in `ReflectionBinding`. {% endhint %}
 
 **Option 3**: Using a common namespace which can combine multiple namespaces: 
 

--- a/guides/basics/introduction-to-xaml.md
+++ b/guides/basics/introduction-to-xaml.md
@@ -61,6 +61,8 @@ xmlns:myAlias3="using:My.NameSpace"
 
 {% hint style="info" %} `My.NameSpace` is the namespace in `C#` you want to use {% endhint %}
 
+{% hint style="warning" %} `using`-syntax cannot be used in case of reflection based type resolution like in `ReflectionBinding`. {% endhint %}
+
 **Option 3**: Using a common namespace which can combine multiple namespaces: 
 
 Some libraries have their own common namespace defined, like Avalonia does. Often they use an URL like `https://github.com/avaloniaui`, but it can be any string. Usage: 

--- a/guides/basics/introduction-to-xaml.md
+++ b/guides/basics/introduction-to-xaml.md
@@ -49,7 +49,7 @@ xmlns:myAlias1="clr-namespace:My.NameSpace"
 xmlns:myAlias2="clr-namespace:My.NameSpace.InOtherAssembly;assembly=TheOtherAssembly"
 ```
 
-{% hint style="info" %} `My.NameSpace` is the namespace in `C#` you want to use {% endhint %}
+{% hint style="info" %} `My.NameSpace` is the namespace in `C#` you want to use. {% endhint %}
 
 {% hint style="info" %} You can omit the `assembly` part if your namespace is in the same assembly. {% endhint %}
 
@@ -59,7 +59,7 @@ xmlns:myAlias2="clr-namespace:My.NameSpace.InOtherAssembly;assembly=TheOtherAsse
 xmlns:myAlias3="using:My.NameSpace"
 ```
 
-{% hint style="info" %} `My.NameSpace` is the namespace in `C#` you want to use {% endhint %}
+{% hint style="info" %} `My.NameSpace` is the namespace in `C#` you want to use. {% endhint %}
 
 {% hint style="warning" %} `using`-syntax cannot be used in case of reflection based type resolution like in `ReflectionBinding`. {% endhint %}
 


### PR DESCRIPTION
## What does the pull request do?

Adds a note about `using`-syntax namespaces being not supported for runtime type resolution. See AvaloniaUI/Avalonia#11347

**Scope of this PR:**
- [x] fix or update to an existing page
- [ ] add a new page to the docs

## Checklist
<!-- Please fill out the checklist below.  -->

**If this is a new Page**
- [ ] Added the new page to [Summary.md](https://docs.gitbook.com/getting-started/git-sync/content-configuration#summary)

**In any case**
- [x] Spell-checking done
- [ ] Checked if all hyperlinks work
- [ ] Checked if all images are visible